### PR TITLE
Type string enums and flags

### DIFF
--- a/deltachat/account.go
+++ b/deltachat/account.go
@@ -24,7 +24,7 @@ func (self *Account) GetEventChannel() <-chan *Event {
 }
 
 // Get next event matching the given type.
-func (self *Account) WaitForEvent(eventType string) *Event {
+func (self *Account) WaitForEvent(eventType EventType) *Event {
 	eventChan := self.GetEventChannel()
 	for {
 		event := <-eventChan
@@ -167,7 +167,7 @@ func (self *Account) QueryContacts(query string, listFlags uint) ([]*Contact, er
 
 // This account's identity as a Contact.
 func (self *Account) Me() *Contact {
-	return &Contact{self, CONTACT_SELF}
+	return &Contact{self, ContactSelf}
 }
 
 // Create a 1:1 chat with the given account.

--- a/deltachat/account_test.go
+++ b/deltachat/account_test.go
@@ -38,7 +38,7 @@ func TestAccount_WaitForEvent(t *testing.T) {
 
 	_, err := acc.CreateContact("test@example.com", "test")
 	assert.Nil(t, err)
-	acc.WaitForEvent(EVENT_CONTACTS_CHANGED)
+	acc.WaitForEvent(EventContactsChanged)
 }
 
 func TestAccount_Select(t *testing.T) {
@@ -295,10 +295,10 @@ func TestAccount_QrCode(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, chat2)
 
-	event := WaitForEvent(acc, EVENT_SECUREJOIN_INVITER_PROGRESS)
+	event := WaitForEvent(acc, EventSecurejoinInviterProgress)
 	assert.NotNil(t, event)
 
-	event = WaitForEvent(acc2, EVENT_SECUREJOIN_JOINER_PROGRESS)
+	event = WaitForEvent(acc2, EventSecurejoinJoinerProgress)
 	assert.NotNil(t, event)
 }
 

--- a/deltachat/bot.go
+++ b/deltachat/bot.go
@@ -12,7 +12,7 @@ type NewMsgHandler func(msg *Message)
 type Bot struct {
 	Account         *Account
 	newMsgHandler   NewMsgHandler
-	handlerMap      map[string]EventHandler
+	handlerMap      map[EventType]EventHandler
 	handlerMapMutex sync.RWMutex
 	quitChan        chan struct{}
 	running         bool
@@ -20,7 +20,7 @@ type Bot struct {
 
 // Create a new Bot that will process events from the given account
 func NewBot(account *Account) *Bot {
-	return &Bot{Account: account, handlerMap: make(map[string]EventHandler), quitChan: make(chan struct{})}
+	return &Bot{Account: account, handlerMap: make(map[EventType]EventHandler), quitChan: make(chan struct{})}
 }
 
 // Helper function to create a new Bot from the given AccountManager.
@@ -43,14 +43,14 @@ func (self *Bot) String() string {
 
 // Set an EventHandler for the given event type. Calling On() several times
 // with the same event type will override the previously set EventHandler.
-func (self *Bot) On(event string, handler EventHandler) {
+func (self *Bot) On(event EventType, handler EventHandler) {
 	self.handlerMapMutex.Lock()
 	self.handlerMap[event] = handler
 	self.handlerMapMutex.Unlock()
 }
 
 // Remove EventHandler for the given event type.
-func (self *Bot) RemoveEventHandler(event string) {
+func (self *Bot) RemoveEventHandler(event EventType) {
 	self.handlerMapMutex.Lock()
 	delete(self.handlerMap, event)
 	self.handlerMapMutex.Unlock()
@@ -119,7 +119,7 @@ func (self *Bot) Run() {
 				return
 			}
 			self.onEvent(event)
-			if event.Type == EVENT_INCOMING_MSG {
+			if event.Type == EventIncomingMsg {
 				self.processMessages()
 			}
 		}

--- a/deltachat/bot_test.go
+++ b/deltachat/bot_test.go
@@ -51,7 +51,7 @@ func TestBot_OnNewMsg(t *testing.T) {
 	assert.Nil(t, err)
 
 	incomingMsg := make(chan *MsgSnapshot)
-	bot.On(EVENT_INCOMING_MSG, func(event *Event) {
+	bot.On(EventIncomingMsg, func(event *Event) {
 		msg := &Message{bot.Account, event.MsgId}
 		snapshot, _ := msg.Snapshot()
 		incomingMsg <- snapshot
@@ -60,7 +60,7 @@ func TestBot_OnNewMsg(t *testing.T) {
 	chatWithBot1.SendText("test1")
 	msg := <-incomingMsg
 	assert.Equal(t, "test1", msg.Text)
-	bot.RemoveEventHandler(EVENT_INCOMING_MSG)
+	bot.RemoveEventHandler(EventIncomingMsg)
 	close(incomingMsg)
 
 	acc2 := acfactory.GetOnlineAccount()

--- a/deltachat/chat.go
+++ b/deltachat/chat.go
@@ -121,22 +121,22 @@ func (self *Chat) RemoveImage() error {
 
 // Pin this chat.
 func (self *Chat) Pin() error {
-	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, CHAT_VISIBILITY_PINNED)
+	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, ChatVisibilityPinned)
 }
 
 // Unpin this chat.
 func (self *Chat) Unpin() error {
-	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, CHAT_VISIBILITY_NORMAL)
+	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, ChatVisibilityNormal)
 }
 
 // Archive this chat.
 func (self *Chat) Archive() error {
-	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, CHAT_VISIBILITY_ARCHIVED)
+	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, ChatVisibilityArchived)
 }
 
 // Unarchive this chat.a
 func (self *Chat) Unarchive() error {
-	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, CHAT_VISIBILITY_NORMAL)
+	return self.rpc().Call("set_chat_visibility", self.Account.Id, self.Id, ChatVisibilityNormal)
 }
 
 // Add contact to this group.

--- a/deltachat/const.go
+++ b/deltachat/const.go
@@ -1,102 +1,116 @@
 package deltachat
 
+type ChatListFlag uint
+
+type ContactFlag uint
+
+type ChatVisibility string
+
+type DownloadState string
+
+type MsgType string
+
+type SysmsgType string
+
+type EventType string
+
 const (
 	//Special contact ids
-	CONTACT_SELF         ContactId = 1
-	CONTACT_INFO         ContactId = 2
-	CONTACT_DEVICE       ContactId = 5
-	CONTACT_LAST_SPECIAL ContactId = 9
+	ContactSelf        ContactId = 1
+	ContactInfo        ContactId = 2
+	ContactDevice      ContactId = 5
+	ContactLastSpecial ContactId = 9
 
 	// Chatlist Flags
-	CHATLIST_FLAG_ARCHIVED_ONLY    uint = 0x01
-	CHATLIST_FLAG_NO_SPECIALS      uint = 0x02
-	CHATLIST_FLAG_ADD_ALLDONE_HINT uint = 0x04
-	CHATLIST_FLAG_FOR_FORWARDING   uint = 0x08
+	ChatListFlagArchivedOnly   ChatListFlag = 0x01
+	ChatListFlagNoSpecials     ChatListFlag = 0x02
+	ChatListFlagAddAlldoneHint ChatListFlag = 0x04
+	ChatListFlagForForwarding  ChatListFlag = 0x08
 
 	// Contact Flags
-	CONTACT_FLAG_VERIFIED_ONLY = 0x01
-	CONTACT_FLAG_ADD_SELF      = 0x02
+	ContactFlagVerifiedOnly ContactFlag = 0x01
+	ContactFlagAddSelf      ContactFlag = 0x02
 
 	//Chat types
-	CHAT_TYPE_UNDEFINED   ChatType = 0
-	CHAT_TYPE_SINGLE      ChatType = 100
-	CHAT_TYPE_GROUP       ChatType = 120
-	CHAT_TYPE_MAILINGLIST ChatType = 140
-	CHAT_TYPE_BROADCAST   ChatType = 160
+	ChatUndefined   ChatType = 0
+	ChatSingle      ChatType = 100
+	ChatGroup       ChatType = 120
+	ChatMailinglist ChatType = 140
+	ChatBroadcast   ChatType = 160
 
 	// Chat visibility types
-	CHAT_VISIBILITY_NORMAL   = "Normal"
-	CHAT_VISIBILITY_ARCHIVED = "Archived"
-	CHAT_VISIBILITY_PINNED   = "Pinned"
+	ChatVisibilityNormal   ChatVisibility = "Normal"
+	ChatVisibilityArchived ChatVisibility = "Archived"
+	ChatVisibilityPinned   ChatVisibility = "Pinned"
 
 	//Message download states
-	DOWNLOAD_STATE_DONE        = "Done"
-	DOWNLOAD_STATE_AVAILABLE   = "Available"
-	DOWNLOAD_STATE_FAILURE     = "Failure"
-	DOWNLOAD_STATE_IN_PROGRESS = "InProgress"
+	DownloadDone       DownloadState = "Done"
+	DownloadAvailable  DownloadState = "Available"
+	DownloadFailure    DownloadState = "Failure"
+	DownloadInProgress DownloadState = "InProgress"
 
 	//Message view types
-	MSG_TYPE_UNKNOWN              = "Unknown"
-	MSG_TYPE_TEXT                 = "Text"
-	MSG_TYPE_IMAGE                = "Image"
-	MSG_TYPE_GIF                  = "Gif"
-	MSG_TYPE_STICKER              = "Sticker"
-	MSG_TYPE_AUDIO                = "Audio"
-	MSG_TYPE_VOICE                = "Voice"
-	MSG_TYPE_VIDEO                = "Video"
-	MSG_TYPE_FILE                 = "File"
-	MSG_TYPE_VIDEOCHAT_INVITATION = "VideochatInvitation"
-	MSG_TYPE_WEBXDC               = "Webxdc"
+	MsgUnknown             MsgType = "Unknown"
+	MsgText                MsgType = "Text"
+	MsgImage               MsgType = "Image"
+	MsgGif                 MsgType = "Gif"
+	MsgSticker             MsgType = "Sticker"
+	MsgAudio               MsgType = "Audio"
+	MsgVoice               MsgType = "Voice"
+	MsgVideo               MsgType = "Video"
+	MsgFile                MsgType = "File"
+	MsgVideochatInvitation MsgType = "VideochatInvitation"
+	MsgWebxdc              MsgType = "Webxdc"
 
 	//System message types
-	SYSMSG_TYPE_UNKNOWN                    = "Unknown"
-	SYSMSG_TYPE_GROUP_NAME_CHANGED         = "GroupNameChanged"
-	SYSMSG_TYPE_GROUP_IMAGE_CHANGED        = "GroupImageChanged"
-	SYSMSG_TYPE_MEMBER_ADDED_TO_GROUP      = "MemberAddedToGroup"
-	SYSMSG_TYPE_MEMBER_REMOVED_FROM_GROUP  = "MemberRemovedFromGroup"
-	SYSMSG_TYPE_AUTOCRYPT_SETUP_MESSAGE    = "AutocryptSetupMessage"
-	SYSMSG_TYPE_SECUREJOIN_MESSAGE         = "SecurejoinMessage"
-	SYSMSG_TYPE_LOCATION_STREAMING_ENABLED = "LocationStreamingEnabled"
-	SYSMSG_TYPE_LOCATION_ONLY              = "LocationOnly"
-	SYSMSG_TYPE_CHAT_PROTECTION_ENABLED    = "ChatProtectionEnabled"
-	SYSMSG_TYPE_CHAT_PROTECTION_DISABLED   = "ChatProtectionDisabled"
-	SYSMSG_TYPE_WEBXDC_STATUS_UPDATE       = "WebxdcStatusUpdate"
-	SYSMSG_TYPE_EPHEMERAL_TIMER_CHANGED    = "EphemeralTimerChanged"
-	SYSMSG_TYPE_MULTI_DEVICE_SYNC          = "MultiDeviceSync"
-	SYSMSG_TYPE_WEBXDC_INFO_MESSAGE        = "WebxdcInfoMessage"
+	SysmsgUnknown                  SysmsgType = "Unknown"
+	SysmsgGroupNameChanged         SysmsgType = "GroupNameChanged"
+	SysmsgGroupImageChanged        SysmsgType = "GroupImageChanged"
+	SysmsgMemberAddedToGroup       SysmsgType = "MemberAddedToGroup"
+	SysmsgMemberRemovedFromGroup   SysmsgType = "MemberRemovedFromGroup"
+	SysmsgAutocryptSetupMessage    SysmsgType = "AutocryptSetupMessage"
+	SysmsgSecurejoinMessage        SysmsgType = "SecurejoinMessage"
+	SysmsgLocationStreamingEnabled SysmsgType = "LocationStreamingEnabled"
+	SysmsgLocationOnly             SysmsgType = "LocationOnly"
+	SysmsgChatProtectionEnabled    SysmsgType = "ChatProtectionEnabled"
+	SysmsgChatProtectionDisabled   SysmsgType = "ChatProtectionDisabled"
+	SysmsgWebxdcStatusUpdate       SysmsgType = "WebxdcStatusUpdate"
+	SysmsgEphemeralTimerChanged    SysmsgType = "EphemeralTimerChanged"
+	SysmsgMultiDeviceSync          SysmsgType = "MultiDeviceSync"
+	SysmsgWebxdcInfoMessage        SysmsgType = "WebxdcInfoMessage"
 
 	// Event types
-	EVENT_INFO                          = "Info"
-	EVENT_SMTP_CONNECTED                = "SmtpConnected"
-	EVENT_IMAP_CONNECTED                = "ImapConnected"
-	EVENT_SMTP_MESSAGE_SENT             = "SmtpMessageSent"
-	EVENT_IMAP_MESSAGE_DELETED          = "ImapMessageDeleted"
-	EVENT_IMAP_MESSAGE_MOVED            = "ImapMessageMoved"
-	EVENT_IMAP_INBOX_IDLE               = "ImapInboxIdle"
-	EVENT_NEW_BLOB_FILE                 = "NewBlobFile"
-	EVENT_DELETED_BLOB_FILE             = "DeletedBlobFile"
-	EVENT_WARNING                       = "Warning"
-	EVENT_ERROR                         = "Error"
-	EVENT_ERROR_SELF_NOT_IN_GROUP       = "ErrorSelfNotInGroup"
-	EVENT_MSGS_CHANGED                  = "MsgsChanged"
-	EVENT_REACTIONS_CHANGED             = "ReactionsChanged"
-	EVENT_INCOMING_MSG                  = "IncomingMsg"
-	EVENT_INCOMING_MSG_BUNCH            = "IncomingMsgBunch"
-	EVENT_MSGS_NOTICED                  = "MsgsNoticed"
-	EVENT_MSG_DELIVERED                 = "MsgDelivered"
-	EVENT_MSG_FAILED                    = "MsgFailed"
-	EVENT_MSG_READ                      = "MsgRead"
-	EVENT_CHAT_MODIFIED                 = "ChatModified"
-	EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED = "ChatEphemeralTimerModified"
-	EVENT_CONTACTS_CHANGED              = "ContactsChanged"
-	EVENT_LOCATION_CHANGED              = "LocationChanged"
-	EVENT_CONFIGURE_PROGRESS            = "ConfigureProgress"
-	EVENT_IMEX_PROGRESS                 = "ImexProgress"
-	EVENT_IMEX_FILE_WRITTEN             = "ImexFileWritten"
-	EVENT_SECUREJOIN_INVITER_PROGRESS   = "SecurejoinInviterProgress"
-	EVENT_SECUREJOIN_JOINER_PROGRESS    = "SecurejoinJoinerProgress"
-	EVENT_CONNECTIVITY_CHANGED          = "ConnectivityChanged"
-	EVENT_SELFAVATAR_CHANGED            = "SelfavatarChanged"
-	EVENT_WEBXDC_STATUS_UPDATE          = "WebxdcStatusUpdate"
-	EVENT_WEBXDC_INSTANCE_DELETED       = "WebxdcInstanceDeleted"
+	EventInfo                       EventType = "Info"
+	EventSmtpConnected              EventType = "SmtpConnected"
+	EventImapConnected              EventType = "ImapConnected"
+	EventSmtpMessageSent            EventType = "SmtpMessageSent"
+	EventImapMessageDeleted         EventType = "ImapMessageDeleted"
+	EventImapMessageMoved           EventType = "ImapMessageMoved"
+	EventImapInboxIdle              EventType = "ImapInboxIdle"
+	EventNewBlobFile                EventType = "NewBlobFile"
+	EventDeletedBlobFile            EventType = "DeletedBlobFile"
+	EventWarning                    EventType = "Warning"
+	EventError                      EventType = "Error"
+	EventErrorSelfNotInGroup        EventType = "ErrorSelfNotInGroup"
+	EventMsgsChanged                EventType = "MsgsChanged"
+	EventReactionsChanged           EventType = "ReactionsChanged"
+	EventIncomingMsg                EventType = "IncomingMsg"
+	EventIncomingMsgBunch           EventType = "IncomingMsgBunch"
+	EventMsgsNoticed                EventType = "MsgsNoticed"
+	EventMsgDelivered               EventType = "MsgDelivered"
+	EventMsgFailed                  EventType = "MsgFailed"
+	EventMsgRead                    EventType = "MsgRead"
+	EventChatModified               EventType = "ChatModified"
+	EventChatEphemeralTimerModified EventType = "ChatEphemeralTimerModified"
+	EventContactsChanged            EventType = "ContactsChanged"
+	EventLocationChanged            EventType = "LocationChanged"
+	EventConfigureProgress          EventType = "ConfigureProgress"
+	EventImexProgress               EventType = "ImexProgress"
+	EventImexFileWritten            EventType = "ImexFileWritten"
+	EventSecurejoinInviterProgress  EventType = "SecurejoinInviterProgress"
+	EventSecurejoinJoinerProgress   EventType = "SecurejoinJoinerProgress"
+	EventConnectivityChanged        EventType = "ConnectivityChanged"
+	EventSelfavatarChanged          EventType = "SelfavatarChanged"
+	EventWebxdcStatusUpdate         EventType = "WebxdcStatusUpdate"
+	EventWebxdcInstanceDeleted      EventType = "WebxdcInstanceDeleted"
 )

--- a/deltachat/main_test.go
+++ b/deltachat/main_test.go
@@ -94,7 +94,7 @@ func (self *AcFactory) GetOnlineAccount() *Account {
 }
 
 func (self *AcFactory) GetNextMsg(account *Account) (*MsgSnapshot, error) {
-	event := WaitForEvent(account, EVENT_INCOMING_MSG)
+	event := WaitForEvent(account, EventIncomingMsg)
 	msg := Message{account, event.MsgId}
 	return msg.Snapshot()
 }
@@ -102,7 +102,7 @@ func (self *AcFactory) GetNextMsg(account *Account) (*MsgSnapshot, error) {
 func (self *AcFactory) IntroduceEachOther(account1, account2 *Account) {
 	chat, _ := account1.CreateChat(account2)
 	chat.SendText("hi")
-	waitForEvent(account1, EVENT_MSGS_CHANGED, chat.Id)
+	waitForEvent(account1, EventMsgsChanged, chat.Id)
 	snapshot, _ := self.GetNextMsg(account2)
 	if snapshot.Text != "hi" {
 		panic("unexpected message: " + snapshot.Text)
@@ -111,7 +111,7 @@ func (self *AcFactory) IntroduceEachOther(account1, account2 *Account) {
 	chat = &Chat{account2, snapshot.ChatId}
 	chat.Accept()
 	chat.SendText("hello")
-	waitForEvent(account2, EVENT_MSGS_CHANGED, chat.Id)
+	waitForEvent(account2, EventMsgsChanged, chat.Id)
 	snapshot, _ = self.GetNextMsg(account1)
 	if snapshot.Text != "hello" {
 		panic("unexpected message: " + snapshot.Text)
@@ -178,7 +178,7 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func waitForEvent(account *Account, eventType string, chatId ChatId) *Event {
+func waitForEvent(account *Account, eventType EventType, chatId ChatId) *Event {
 	for {
 		event := WaitForEvent(account, eventType)
 		if event.ChatId == chatId {
@@ -187,7 +187,7 @@ func waitForEvent(account *Account, eventType string, chatId ChatId) *Event {
 	}
 }
 
-func WaitForEvent(account *Account, eventType string) *Event {
+func WaitForEvent(account *Account, eventType EventType) *Event {
 	eventChan := account.GetEventChannel()
 	debug := os.Getenv("TEST_DEBUG") == "1"
 	for {

--- a/deltachat/message.go
+++ b/deltachat/message.go
@@ -8,7 +8,7 @@ type MsgId uint64
 type MsgData struct {
 	Text               string      `json:"text,omitempty"`
 	Html               string      `json:"html,omitempty"`
-	ViewType           string      `json:"viewtype,omitempty"`
+	ViewType           MsgType     `json:"viewtype,omitempty"`
 	File               string      `json:"file,omitempty"`
 	Location           *[2]float64 `json:"location,omitempty"`
 	OverrideSenderName string      `json:"overrideSenderName,omitempty"`
@@ -24,7 +24,7 @@ type MsgQuote struct {
 	OverrideSenderName string
 	Image              string
 	IsForwarded        bool
-	ViewType           string
+	ViewType           MsgType
 }
 
 // Message search result.

--- a/deltachat/message_test.go
+++ b/deltachat/message_test.go
@@ -79,7 +79,7 @@ func TestMessage_StatusUpdates(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Nil(t, msg.SendStatusUpdate(`{"payload": "test payload"}`, "update 1"))
-	WaitForEvent(acc2, EVENT_WEBXDC_STATUS_UPDATE)
+	WaitForEvent(acc2, EventWebxdcStatusUpdate)
 
 	msg = &Message{acc2, snapshot.Id}
 	updates, err := msg.StatusUpdates(0)
@@ -110,7 +110,7 @@ func TestMessage_ContinueAutocryptKeyTransfer(t *testing.T) {
 
 	selfchat, err := acc2.Me().CreateChat()
 	assert.Nil(t, err)
-	event := waitForEvent(acc2, EVENT_MSGS_CHANGED, selfchat.Id)
+	event := waitForEvent(acc2, EventMsgsChanged, selfchat.Id)
 	assert.NotEmpty(t, event.MsgId)
 	msg := &Message{acc2, event.MsgId}
 	assert.Nil(t, msg.ContinueAutocryptKeyTransfer(code))
@@ -144,7 +144,7 @@ func TestMsgSnapshot_ParseMemberAddedRemoved(t *testing.T) {
 	// promote group
 	msg, _ := chat1.SendText("test")
 	for {
-		event := waitForEvent(acc1, EVENT_MSGS_CHANGED, chat1.Id)
+		event := waitForEvent(acc1, EventMsgsChanged, chat1.Id)
 		if event.MsgId == msg.Id {
 			break
 		}
@@ -157,12 +157,12 @@ func TestMsgSnapshot_ParseMemberAddedRemoved(t *testing.T) {
 	// add new member
 	assert.Nil(t, chat1.AddContact(contact2))
 	// acc1 side
-	event := waitForEvent(acc1, EVENT_MSGS_CHANGED, chat1.Id)
+	event := waitForEvent(acc1, EventMsgsChanged, chat1.Id)
 	assert.NotEmpty(t, event.MsgId)
 	msg = &Message{acc1, event.MsgId}
 	snapshot, err = msg.Snapshot()
 	assert.Nil(t, err)
-	assert.Equal(t, SYSMSG_TYPE_MEMBER_ADDED_TO_GROUP, snapshot.SystemMessageType)
+	assert.Equal(t, SysmsgMemberAddedToGroup, snapshot.SystemMessageType)
 	_, _, err = snapshot.ParseMemberRemoved()
 	assert.NotNil(t, err)
 	actor, target, err := snapshot.ParseMemberAdded()
@@ -172,7 +172,7 @@ func TestMsgSnapshot_ParseMemberAddedRemoved(t *testing.T) {
 	// acc2 side
 	snapshot, err = acfactory.GetNextMsg(acc2)
 	assert.Nil(t, err)
-	assert.Equal(t, SYSMSG_TYPE_MEMBER_ADDED_TO_GROUP, snapshot.SystemMessageType)
+	assert.Equal(t, SysmsgMemberAddedToGroup, snapshot.SystemMessageType)
 	actor, target, err = snapshot.ParseMemberAdded()
 	assert.Nil(t, err)
 	assert.Equal(t, contact1, actor)
@@ -181,12 +181,12 @@ func TestMsgSnapshot_ParseMemberAddedRemoved(t *testing.T) {
 	// remove new member
 	assert.Nil(t, chat1.RemoveContact(contact3acc1))
 	// acc1 side
-	event = waitForEvent(acc1, EVENT_MSGS_CHANGED, chat1.Id)
+	event = waitForEvent(acc1, EventMsgsChanged, chat1.Id)
 	assert.NotEmpty(t, event.MsgId)
 	msg = &Message{acc1, event.MsgId}
 	snapshot, err = msg.Snapshot()
 	assert.Nil(t, err)
-	assert.Equal(t, SYSMSG_TYPE_MEMBER_REMOVED_FROM_GROUP, snapshot.SystemMessageType)
+	assert.Equal(t, SysmsgMemberRemovedFromGroup, snapshot.SystemMessageType)
 	_, _, err = snapshot.ParseMemberAdded()
 	assert.NotNil(t, err)
 	actor, target, err = snapshot.ParseMemberRemoved()
@@ -196,7 +196,7 @@ func TestMsgSnapshot_ParseMemberAddedRemoved(t *testing.T) {
 	// acc2 side
 	snapshot, err = acfactory.GetNextMsg(acc2)
 	assert.Nil(t, err)
-	assert.Equal(t, SYSMSG_TYPE_MEMBER_REMOVED_FROM_GROUP, snapshot.SystemMessageType)
+	assert.Equal(t, SysmsgMemberRemovedFromGroup, snapshot.SystemMessageType)
 	actor, target, err = snapshot.ParseMemberRemoved()
 	assert.Nil(t, err)
 	assert.Equal(t, contact1, actor)
@@ -205,12 +205,12 @@ func TestMsgSnapshot_ParseMemberAddedRemoved(t *testing.T) {
 	// leave
 	assert.Nil(t, chat1.Leave())
 	// acc1 side
-	event = waitForEvent(acc1, EVENT_MSGS_CHANGED, chat1.Id)
+	event = waitForEvent(acc1, EventMsgsChanged, chat1.Id)
 	assert.NotEmpty(t, event.MsgId)
 	msg = &Message{acc1, event.MsgId}
 	snapshot, err = msg.Snapshot()
 	assert.Nil(t, err)
-	assert.Equal(t, SYSMSG_TYPE_MEMBER_REMOVED_FROM_GROUP, snapshot.SystemMessageType)
+	assert.Equal(t, SysmsgMemberRemovedFromGroup, snapshot.SystemMessageType)
 	actor, target, err = snapshot.ParseMemberRemoved()
 	assert.Nil(t, err)
 	assert.Equal(t, acc1.Me(), actor)
@@ -218,7 +218,7 @@ func TestMsgSnapshot_ParseMemberAddedRemoved(t *testing.T) {
 	// acc2 side
 	snapshot, err = acfactory.GetNextMsg(acc2)
 	assert.Nil(t, err)
-	assert.Equal(t, SYSMSG_TYPE_MEMBER_REMOVED_FROM_GROUP, snapshot.SystemMessageType)
+	assert.Equal(t, SysmsgMemberRemovedFromGroup, snapshot.SystemMessageType)
 	actor, target, err = snapshot.ParseMemberRemoved()
 	assert.Nil(t, err)
 	assert.Equal(t, contact1, actor)

--- a/deltachat/msgsnapshot.go
+++ b/deltachat/msgsnapshot.go
@@ -18,7 +18,7 @@ type MsgSnapshot struct {
 	Text                  string
 	HasLocation           bool
 	HasHtml               bool
-	ViewType              string
+	ViewType              MsgType
 	State                 int
 	Error                 string
 	Timestamp             int
@@ -31,7 +31,7 @@ type MsgSnapshot struct {
 	IsInfo                bool
 	IsForwarded           bool
 	IsBot                 bool
-	SystemMessageType     string
+	SystemMessageType     SysmsgType
 	Duration              int
 	DimensionsHeight      int
 	DimensionsWidth       int
@@ -45,11 +45,11 @@ type MsgSnapshot struct {
 	FileBytes             uint64
 	FileName              string
 	WebxdcInfo            *WebxdcMsgInfo
-	DownloadState         string
+	DownloadState         DownloadState
 	Reactions             *Reactions
 }
 
-// Extract metadata from system message with type SYSMSG_TYPE_MEMBER_ADDED_TO_GROUP.
+// Extract metadata from system message with type SysmsgTypeMemberAddedToGroup.
 func (self *MsgSnapshot) ParseMemberAdded() (actor *Contact, target *Contact, err error) {
 	action, actor, target, err := self.parseMemberAddRemove()
 	if err != nil {
@@ -61,7 +61,7 @@ func (self *MsgSnapshot) ParseMemberAdded() (actor *Contact, target *Contact, er
 	return nil, nil, fmt.Errorf("System message does not match")
 }
 
-// Extract metadata from system message with type SYSMSG_TYPE_MEMBER_REMOVED_FROM_GROUP.
+// Extract metadata from system message with type SysmsgTypeMemberRemovedFromGroup.
 func (self *MsgSnapshot) ParseMemberRemoved() (actor *Contact, target *Contact, err error) {
 	action, actor, target, err := self.parseMemberAddRemove()
 	if err != nil {

--- a/deltachat/rpc.go
+++ b/deltachat/rpc.go
@@ -14,7 +14,7 @@ import (
 
 // Delta Chat core Event
 type Event struct {
-	Type               string
+	Type               EventType
 	Msg                string
 	File               string
 	ChatId             ChatId

--- a/examples/client.go
+++ b/examples/client.go
@@ -22,13 +22,13 @@ func getAccount(manager *deltachat.AccountManager) *deltachat.Account {
 // Dummy function that just prints some events, here your client's UI would process the event
 func handleEvent(acc *deltachat.Account, event *deltachat.Event) {
 	switch event.Type {
-	case deltachat.EVENT_INFO:
+	case deltachat.EventInfo:
 		log.Println("INFO:", event.Msg)
-	case deltachat.EVENT_WARNING:
+	case deltachat.EventWarning:
 		log.Println("WARNING:", event.Msg)
-	case deltachat.EVENT_ERROR:
+	case deltachat.EventError:
 		log.Println("ERROR:", event.Msg)
-	case deltachat.EVENT_INCOMING_MSG:
+	case deltachat.EventIncomingMsg:
 		msg := deltachat.Message{acc, event.MsgId}
 		snapshot, _ := msg.Snapshot()
 		log.Printf("Got new message from %v: %v", snapshot.Sender.DisplayName, snapshot.Text)

--- a/examples/echobot.go
+++ b/examples/echobot.go
@@ -20,9 +20,9 @@ func main() {
 	log.Println("Running deltachat core", sysinfo["deltachat_core_version"])
 
 	bot := deltachat.NewBotFromAccountManager(manager)
-	bot.On(deltachat.EVENT_INFO, logEvent)
-	bot.On(deltachat.EVENT_WARNING, logEvent)
-	bot.On(deltachat.EVENT_ERROR, logEvent)
+	bot.On(deltachat.EventInfo, logEvent)
+	bot.On(deltachat.EventWarning, logEvent)
+	bot.On(deltachat.EventError, logEvent)
 	bot.OnNewMsg(func(msg *deltachat.Message) {
 		snapshot, _ := msg.Snapshot()
 		chat := deltachat.Chat{bot.Account, snapshot.ChatId}


### PR DESCRIPTION
Redundant words "state" and "type" were removed from some values where they didn't provide additional value.

Closes #5 