### PR TITLE
[WIP] Serialize incoming events

### DIFF
--- a/deltachat/account.go
+++ b/deltachat/account.go
@@ -44,7 +44,7 @@ func (self *Account) Select() error {
 	return self.rpc().Call("select_account", self.Id)
 }
 
-// Start the account I/O.
+// Start the account I/O. You must handle events from the channel returned by GetEventChannel().
 func (self *Account) StartIO() error {
 	return self.rpc().Call("start_io", self.Id)
 }
@@ -114,7 +114,7 @@ func (self *Account) Avatar() (string, error) {
 	return self.GetConfig("selfavatar")
 }
 
-// Configure an account.
+// Configure an account. You must handle events from the channel returned by GetEventChannel().
 func (self *Account) Configure() error {
 	return self.rpc().Call("configure", self.Id)
 }

--- a/deltachat/main_test.go
+++ b/deltachat/main_test.go
@@ -35,6 +35,8 @@ func (self *AcFactory) TearDown() {
 
 func (self *AcFactory) NewAcManager() *AccountManager {
 	rpc := NewRpcIO()
+	rpc.EventBuffer = 1000 // tests don't always have an event loop
+
 	if os.Getenv("TEST_DEBUG") != "1" {
 		rpc.Stderr = nil
 	}


### PR DESCRIPTION
All incoming events are funneled into a channel that is split to per-account channels on read to prevent locking up while keeping order of events consistent for each account.

When opening an account the user is required to call Open() to open the events channel for it or it's possible some events are dropped before StartIO during account configuration.

Previously event order was unknown because they were waiting in separate parallel goroutines.