### PR TITLE
fix(types): initialize Quote field in Message.UnmarshalJSON

### DIFF
--- a/v2/deltachat/types.go
+++ b/v2/deltachat/types.go
@@ -2008,6 +2008,7 @@ func (s *Message) UnmarshalJSON(data []byte) error {
 	s.VcardContact = raw.VcardContact
 	s.ViewType = raw.ViewType
 	s.WebxdcHref = raw.WebxdcHref
+	s.Quote = new(MessageQuote)
 	if len(raw.Quote) > 0 && string(raw.Quote) != "null" {
 		if err := unmarshalMessageQuote(raw.Quote, s.Quote); err != nil {
 			return err

--- a/v2/deltachat/types_test.go
+++ b/v2/deltachat/types_test.go
@@ -403,6 +403,15 @@ func TestUnmarshalMessageQuote(t *testing.T) {
 	require.NotNil(t, unmarshalMessageQuote(json.RawMessage(`{"kind":"Unknown"}`), &out))
 }
 
+func TestMessage_UnmarshalJSON_WithQuote(t *testing.T) {
+	t.Parallel()
+
+	var msg Message
+	require.Nil(t, json.Unmarshal([]byte(`{"chatId":0,"dimensionsHeight":0,"dimensionsWidth":0,"downloadState":"Done","duration":0,"fileBytes":0,"fromId":0,"hasDeviatingTimestamp":false,"hasHtml":false,"hasLocation":false,"id":1,"isBot":false,"isEdited":false,"isForwarded":false,"isInfo":false,"receivedTimestamp":0,"showPadlock":false,"sortTimestamp":0,"state":0,"subject":"","systemMessageType":"Unknown","text":"hello","timestamp":0,"viewType":"Text","quote":{"kind":"JustText","text":"quoted text"},"sender":{"address":"","authName":"","color":"","id":0,"isBlocked":false,"isKeyContact":false,"isVerified":false,"lastSeen":0,"name":"","nameAndAddr":"","profileImage":null,"status":"","verifiedBy":0}}`), &msg))
+	require.NotNil(t, msg.Quote)
+	require.Equal(t, "JustText", (*msg.Quote).GetKind())
+}
+
 func TestMuteDuration_MarshalJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I've initialised the Quote field to avoid nil pointer dereferences when unmarshaling messages with quote data. Previously, if a message contained quote information, the Quote field would remain nil, causing potential panics when accessing quote properties.

Add test case to verify that messages with quotes are properly unmarshaled and the Quote field is correctly initialized. I've tried to keep the same style of yours, hope it's good enough.

> [!NOTE]
> I've tested this manually as well by spinning up my bot locally and it seems to do the trick, with the bug disappearing completely.

---
Closes https://github.com/chatmail/rpc-client-go/issues/41